### PR TITLE
Add optional prompt chain and response logging through Portkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Prompt engineering is kind of like alchemy. There's no clear way to predict what
 
 - **[Weights & Biases](https://wandb.ai/site/prompts) Logging**: Optional logging to [Weights & Biases](https://wandb.ai/site) of your configs such as temperature and max tokens, the system and user prompts for each part, the test cases used and the final ranked ELO rating for each candidate prompt. Set `use_wandb` to `True` to use. 
 
+- **[Portkey](https://portkey.ai)**: Optional tool to log and trace all the prompt chains and their responses. Set `use_portkey` to `True` to use.
+
 ## Setup
 1. [Open the notebook in Google Colab](https://colab.research.google.com/github/mshumer/gpt-prompt-engineer/blob/main/gpt_prompt_engineer.ipynb) or in a local Jupyter notebook. For classification, use [this one.](https://colab.research.google.com/drive/16NLMjqyuUWxcokE_NF6RwHD8grwEeoaJ?usp=sharing)
 

--- a/gpt_prompt_engineer.ipynb
+++ b/gpt_prompt_engineer.ipynb
@@ -59,7 +59,9 @@
         "\n",
         "openai.api_key = \"ADD YOUR KEY HERE\" # enter your OpenAI API key here\n",
         "\n",
-        "use_wandb = False # set to True if you want to use wandb to log your config and results"
+        "use_wandb = False # set to True if you want to use wandb to log your config and results\n",
+        "\n",
+        "use_portkey = False #set to True if you want to use Portkey to log all the prompt chains and their responses Check https://portkey.ai/"
       ]
     },
     {
@@ -115,7 +117,11 @@
         "NUMBER_OF_PROMPTS = 10 # this determines how many candidate prompts to generate... the higher, the more expensive, but the better the results will be\n",
         "\n",
         "WANDB_PROJECT_NAME = \"gpt-prompt-eng\" # used if use_wandb is True, Weights &| Biases project name\n",
-        "WANDB_RUN_NAME = None # used if use_wandb is True, optionally set the Weights & Biases run name to identify this run"
+        "WANDB_RUN_NAME = None # used if use_wandb is True, optionally set the Weights & Biases run name to identify this run\n",
+        "\n",
+        "PORTKEY_API = \"\" # used if use_portkey is True. Get api key here: https://app.portkey.ai/ (click on profile photo on top left)\n",
+        "PORTKEY_TRACE = \"prompt_engineer_test_run\" # used if use_portkey is True. Trace each run with a separate ID to differentiate prompt chains\n",
+        "HEADERS = {} # don't change. headers will auto populate if use_portkey is true."
       ]
     },
     {
@@ -160,6 +166,35 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def start_portkey_run():\n",
+        "  # define Portkey headers to start logging all prompts & their responses\n",
+        "  openai.api_base=\"https://api.portkey.ai/v1/proxy\"\n",
+        "  HEADERS = {\n",
+        "    \"x-portkey-api-key\": PORTKEY_API, \n",
+        "    \"x-portkey-mode\": \"proxy openai\",\n",
+        "    \"x-portkey-trace-id\": PORTKEY_TRACE,\n",
+        "    #\"x-portkey-retry-count\": 5 # perform automatic retries with exponential backoff if the OpenAI requests fails\n",
+        "  } \n",
+        "  return HEADERS"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Optional prompt & responses logging\n",
+        "if use_portkey:\n",
+        "    HEADERS=start_portkey_run()"
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": 13,
       "metadata": {
         "id": "wXeqMQpzzosx"
@@ -174,7 +209,8 @@
         "          {\"role\": \"user\", \"content\": f\"Here are some test cases:`{test_cases}`\\n\\nHere is the description of the use-case: `{description.strip()}`\\n\\nRespond with your prompt, and nothing else. Be creative.\"}\n",
         "          ],\n",
         "      temperature=CANDIDATE_MODEL_TEMPERATURE,\n",
-        "      n=number_of_prompts)\n",
+        "      n=number_of_prompts,\n",
+        "      headers=HEADERS)\n",
         "\n",
         "  prompts = []\n",
         "\n",
@@ -208,6 +244,7 @@
         "        },\n",
         "        max_tokens=1,\n",
         "        temperature=ranking_model_temperature,\n",
+        "        headers=HEADERS,\n",
         "    ).choices[0].message.content\n",
         "    return score\n",
         "\n",
@@ -221,6 +258,7 @@
         "        ],\n",
         "        max_tokens=GENERATION_MODEL_MAX_TOKENS,\n",
         "        temperature=GENERATION_MODEL_TEMPERATURE,\n",
+        "        headers=HEADERS,\n",
         "    ).choices[0].message.content\n",
         "    return generation\n",
         "\n",

--- a/gpt_prompt_engineer_Classification_Version.ipynb
+++ b/gpt_prompt_engineer_Classification_Version.ipynb
@@ -33,7 +33,9 @@
         "2. In the last cell, fill in the description of your task, as many test cases as you want (test cases are example prompts and their expected output), and the number of prompts to generate.\n",
         "3. Run all the cells! The AI will generate a number of candidate prompts, and test them all to find the best one!\n",
         "\n",
-        "🪄🐝 To use [Weights & Biases logging](https://wandb.ai/site/prompts) to your LLM configs and the generated prompt outputs, just set `use_wandb = True`."
+        "🪄🐝 To use [Weights & Biases logging](https://wandb.ai/site/prompts) to your LLM configs and the generated prompt outputs, just set `use_wandb = True`.\n",
+        "\n",
+        "🪄🔮 To use [Portkey](https://docs.portke.ai) for logging and tracing prompt chains and responses, just set `use_portkey = True`."
       ]
     },
     {
@@ -61,7 +63,9 @@
         "\n",
         "openai.api_key = \"ADD YOUR KEY HERE\" # enter your OpenAI API key here\n",
         "\n",
-        "use_wandb = True # set to True if you want to use wandb to log your config and results"
+        "use_wandb = True # set to True if you want to use wandb to log your config and results\n",
+        "\n",
+        "use_portkey = False #set to True if you want to use Portkey to log all the prompt chains and their responses Check https://portkey.ai/"
       ]
     },
     {
@@ -99,7 +103,11 @@
         "N_RETRIES = 3  # number of times to retry a call to the ranking model if it fails\n",
         "\n",
         "WANDB_PROJECT_NAME = \"gpt-prompt-eng\" # used if use_wandb is True, Weights &| Biases project name\n",
-        "WANDB_RUN_NAME = None # used if use_wandb is True, optionally set the Weights & Biases run name to identify this run"
+        "WANDB_RUN_NAME = None # used if use_wandb is True, optionally set the Weights & Biases run name to identify this run\n",
+        "\n",
+        "PORTKEY_API = \"\" # used if use_portkey is True. Get api key here: https://app.portkey.ai/ (click on profile photo on top left)\n",
+        "PORTKEY_TRACE = \"prompt_engineer_classification_test_run\" # used if use_portkey is True. Trace each run with a separate ID to differentiate prompt chains\n",
+        "HEADERS = {} # don't change. headers will auto populate if use_portkey is true."
       ]
     },
     {
@@ -140,6 +148,35 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def start_portkey_run():\n",
+        "  # define Portkey headers to start logging all prompts & their responses\n",
+        "  openai.api_base=\"https://api.portkey.ai/v1/proxy\"\n",
+        "  HEADERS = {\n",
+        "    \"x-portkey-api-key\": PORTKEY_API, \n",
+        "    \"x-portkey-mode\": \"proxy openai\",\n",
+        "    \"x-portkey-trace-id\": PORTKEY_TRACE,\n",
+        "    #\"x-portkey-retry-count\": 5 # perform automatic retries with exponential backoff if the OpenAI requests fails\n",
+        "  } \n",
+        "  return HEADERS"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Optional prompt & responses logging\n",
+        "if use_portkey:\n",
+        "    HEADERS=start_portkey_run()"
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": 34,
       "metadata": {
         "id": "KTRFiBhSouz8"
@@ -156,7 +193,8 @@
         "          {\"role\": \"user\", \"content\": f\"Here are some test cases:`{test_cases}`\\n\\nHere is the description of the use-case: `{description.strip()}`\\n\\nRespond with your prompt, and nothing else. Be creative.\"}\n",
         "          ],\n",
         "      temperature=CANDIDATE_MODEL_TEMPERATURE,\n",
-        "      n=number_of_prompts)\n",
+        "      n=number_of_prompts,\n",
+        "      headers=HEADERS)\n",
         "\n",
         "  prompts = []\n",
         "\n",
@@ -204,6 +242,7 @@
         "              },\n",
         "              max_tokens=EVAL_MODEL_MAX_TOKENS,\n",
         "              temperature=EVAL_MODEL_TEMPERATURE,\n",
+        "              headers=HEADERS\n",
         "          ).choices[0].message.content\n",
         "\n",
         "\n",


### PR DESCRIPTION
optional feature that creates detailed logs of all prompt chains and their responses using [Portkey](https://portkey.ai/).

details:
- added `use_portkey`, similar to `use_wandb`
- requires Portkey API key which can be obtained by visiting https://portkey.ai/
- `use_portkey` is set to `False` by default

logging will make experimentation more robust, and help debug issues easily.

snippet of the logging screen:
https://github.com/mshumer/gpt-prompt-engineer/assets/134934501/a1f0800f-52ce-403c-9a7c-9830ca8f6201
