### PR TITLE
Fix typo in candiate_model

### DIFF
--- a/gpt_prompt_engineer.ipynb
+++ b/gpt_prompt_engineer.ipynb
@@ -139,7 +139,7 @@
         "      \"K\": K,\n",
         "      \"system_gen_system_prompt\": system_gen_system_prompt, \n",
         "      \"ranking_system_prompt\": ranking_system_prompt,\n",
-        "      \"candiate_model\": CANDIDATE_MODEL,\n",
+        "      \"candidate_model\": CANDIDATE_MODEL,\n",
         "      \"candidate_model_temperature\": CANDIDATE_MODEL_TEMPERATURE,\n",
         "      \"generation_model\": GENERATION_MODEL,\n",
         "      \"generation_model_temperature\": GENERATION_MODEL_TEMPERATURE,\n",


### PR DESCRIPTION
This PR just fixes a typo in the `candiate_model` parameter  