### PR TITLE
Fix APIRemovedInV1 error by downgrading OpenAI library to v0.28

### DIFF
--- a/gpt_prompt_engineer.ipynb
+++ b/gpt_prompt_engineer.ipynb
@@ -38,7 +38,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!pip install openai prettytable tqdm tenacity wandb -qq"
+        "!pip install openai==0.28 prettytable tqdm tenacity wandb -qq"
       ]
     },
     {


### PR DESCRIPTION
This commit resolves the `APIRemovedInV1` error in the Google Colab notebook by downgrading the OpenAI Python library to version `0.28`. The error was caused by attempting to access the deprecated `openai.ChatCompletion` method in versions `1.0.0` and above.

Pinning the library to the older version ensures compatibility with the existing codebase and allows the code to function correctly without accessing the deprecated method.
<img width="1396" alt="Screenshot · Arc gpt_prompt_engineer ipynb - Colab · 2024-04-10 at 19 31 59@2x" src="https://github.com/mshumer/gpt-prompt-engineer/assets/34505954/1a1824c1-1a93-4ab0-a48e-95b94497951f">

```
---------------------------------------------------------------------------
APIRemovedInV1                            Traceback (most recent call last)
[<ipython-input-11-5fb2904844c6>](https://localhost:8080/#) in <cell line: 1>()
----> 1 generate_optimal_prompt(description, test_cases, NUMBER_OF_PROMPTS, use_wandb)

2 frames
[/usr/local/lib/python3.10/dist-packages/openai/lib/_old_api.py](https://localhost:8080/#) in __call__(self, *_args, **_kwargs)
     37 
     38     def __call__(self, *_args: Any, **_kwargs: Any) -> Any:
---> 39         raise APIRemovedInV1(symbol=self._symbol)
     40 
     41 

APIRemovedInV1: 

You tried to access openai.ChatCompletion, but this is no longer supported in openai>=1.0.0 - see the README at https://github.com/openai/openai-python for the API.

You can run `openai migrate` to automatically upgrade your codebase to use the 1.0.0 interface. 

Alternatively, you can pin your installation to the old version, e.g. `pip install openai==0.28`

A detailed migration guide is available here: https://github.com/openai/openai-python/discussions/742
<img width="1396" alt="Screenshot · Arc gpt_prompt_engineer ipynb - Colab · 2024-04-10 at 19 31 59@2x" src="https://github.com/mshumer/gpt-prompt-engineer/assets/34505954/23c46d88-4072-4134-a4fd-83c6274d566b">

```